### PR TITLE
Edit lecture paths

### DIFF
--- a/app.py
+++ b/app.py
@@ -21,7 +21,7 @@ import requests
 
 from utils.db_utils import User, Course, Lecture, Vitamin, Resource, Video, Transcript
 import utils.lecture_utils as LectureUtils
-import utils.piazza as Piazza
+# import utils.piazza_client as Piazza
 from utils.errors import CreateLectureFormValidationError
 
 from pprint import pprint
@@ -420,33 +420,57 @@ def create_course(course_ok_id, ok_id=None):
         pprint(course)
     return jsonify(success=False, message="Can only create a course on Hermes for an OK course you are a part of"), 403
 
-@app.route('/course/<course_ok_id>/create_piazza_bot', methods=["POST"])
+@app.route('/course/<course_ok_id>/lecture/<lecture_url_name>/video/<int:video_index>/create_vitamin', methods=["POST"])
 @validate_and_pass_on_ok_id
-def create_piazza_bot(course_ok_id, ok_id=None):
+def create_vitamin(course_ok_id, lecture_url_name, video_index, ok_id=None):
+    """Creates a vitamin in the specified video within a lecture of a course."""
+
     user_courses = get_updated_user_courses()
     int_course_ok_id = int(course_ok_id)
-    seperate_folders = request.form["piazza_folders"].split(" ")
     for course in user_courses:
         if course['course_id'] == int_course_ok_id:
-            print(int_course_ok_id)
-            if course['role'] == consts.INSTRUCTOR or user_courses[course_ok_id_key] == consts.STAFF:
-                if not request.form["piazza_course_id"].isalnum():
-                    return jsonify(success=False, message="Please Enter a Valid Pizza API"), 403
-                if not seperate_folders:
-                    return jsonify(success=False, message="Must include at one least folder for posts to go in"), 403
-                try:
-                    Piazza.create_master_post(folders = seperate_folders, \
-                    piazza_course_id  = request.form["piazza_course_id"], content = request.form["content"])
-                    db['Courses'].update(
-                        {'course_ok_id': course_ok_id},
-                        {"$set" :
-                            {"piazza_course_id" : request.form["piazza_course_id"],
-                            "piazza_folders" : seperate_folders,
-                            "piazza_active" : True}
-                        }
-                    )
-                    return jsonify(success=True), 200
-                except ValueError as e:
-                    return jsonify(success=False, message= consts.PIAZZA_ERROR_MESSAGE), 403
-            return jsonify(success=False, message="Only staff can create a Piazza Bot"), 403
-    return jsonify(success=False, message="Can only create a PiazzaBot on behalf of Hermes for an OK course you are a part of"), 403
+            if course['role'] == consts.INSTRUCTOR:
+                if db[Course.collection].find_one({
+                    'course_ok_id': course_ok_id, 
+                    'lecture_url_name': lecture_url_name,
+                    'video_index': video_index
+                }):
+                    try:
+                        form_data = request.form.to_dict()
+                        Vitamin.add_vitamin(form_data, db)
+                        return jsonify(success=True), 200
+                    except ValueError as e:
+                        return jsonify(success=False, message=str(e)), 500
+            return jsonify(success=False, message="Only instructors can create vitamins"), 403
+    return jsonify(success=False, message="Can only create a vitamin on Hermes for an OK course you are a part of"), 403
+
+# @app.route('/course/<course_ok_id>/create_piazza_bot', methods=["POST"])
+# @validate_and_pass_on_ok_id
+# def create_piazza_bot(course_ok_id, ok_id=None):
+#     user_courses = get_updated_user_courses()
+#     int_course_ok_id = int(course_ok_id)
+#     seperate_folders = request.form["piazza_folders"].split(" ")
+#     for course in user_courses:
+#         if course['course_id'] == int_course_ok_id:
+#             print(int_course_ok_id)
+#             if course['role'] == consts.INSTRUCTOR or user_courses[course_ok_id_key] == consts.STAFF:
+#                 if not request.form["piazza_course_id"].isalnum():
+#                     return jsonify(success=False, message="Please Enter a Valid Pizza API"), 403
+#                 if not seperate_folders:
+#                     return jsonify(success=False, message="Must include at one least folder for posts to go in"), 403
+#                 try:
+#                     Piazza.create_master_post(folders = seperate_folders, \
+#                     piazza_course_id  = request.form["piazza_course_id"], content = request.form["content"])
+#                     db['Courses'].update(
+#                         {'course_ok_id': course_ok_id},
+#                         {"$set" :
+#                             {"piazza_course_id" : request.form["piazza_course_id"],
+#                             "piazza_folders" : seperate_folders,
+#                             "piazza_active" : True}
+#                         }
+#                     )
+#                     return jsonify(success=True), 200
+#                 except ValueError as e:
+#                     return jsonify(success=False, message= consts.PIAZZA_ERROR_MESSAGE), 403
+#             return jsonify(success=False, message="Only staff can create a Piazza Bot"), 403
+#     return jsonify(success=False, message="Can only create a PiazzaBot on behalf of Hermes for an OK course you are a part of"), 403

--- a/app.py
+++ b/app.py
@@ -438,7 +438,7 @@ def create_vitamin(course_ok_id, lecture_url_name, video_index, ok_id=None):
                     try:
                         vitamin = request.get_json().get('vitamin')
                         Vitamin.add_vitamin(
-                            course_ok_id = int_course_ok_id,
+                            course_ok_id = course_ok_id,
                             lecture_url_name = lecture_url_name,
                             video_index = video_index,
                             data = vitamin, 
@@ -468,7 +468,7 @@ def create_resource(course_ok_id, lecture_url_name, video_index, ok_id=None):
                     try:
                         link = request.form.to_dict()['link']
                         Resource.add_resource(
-                            course_ok_id = int_course_ok_id,
+                            course_ok_id = course_ok_id,
                             lecture_url_name = lecture_url_name,
                             video_index = video_index,
                             link = link, 

--- a/app.py
+++ b/app.py
@@ -480,6 +480,48 @@ def create_resource(course_ok_id, lecture_url_name, video_index, ok_id=None):
             return jsonify(success=False, message="Only instructors can create resources"), 403
     return jsonify(success=False, message="Can only create a resource on Hermes for an OK course you are a part of"), 403
 
+@app.route('/course/<course_ok_id>/lecture/<lecture_url_name>/video/<int:video_index>/delete_vitamin/<int:vitamin_index>', methods=["DELETE"])
+@validate_and_pass_on_ok_id
+def delete_vitamin(course_ok_id, lecture_url_name, video_index, vitamin_index, ok_id=None):
+    """Deletes a specified vitamin within a specific video of a lecture in a given course."""
+    user_courses = get_updated_user_courses()
+    int_course_ok_id = int(course_ok_id)
+    for course in user_courses:
+        if course['course_id'] == int_course_ok_id:
+            if course['role'] != consts.INSTRUCTOR:
+                return jsonify(success=False, message="Only instructors can delete vitamins"), 403
+            db[Vitamin.collection].delete_one(
+                {
+                    'course_ok_id': course_ok_id,
+                    'lecture_url_name': lecture_url_name,
+                    'video_index': video_index,
+                    'vitamin_index': vitamin_index
+                }
+            )
+            return jsonify(success=True), 200
+    return jsonify(success=False, message="Can only delete a vitamin on Hermes for an OK course you are a part of"), 403
+
+@app.route('/course/<course_ok_id>/lecture/<lecture_url_name>/video/<int:video_index>/delete_resource/<int:resource_index>', methods=["DELETE"])
+@validate_and_pass_on_ok_id
+def delete_resource(course_ok_id, lecture_url_name, video_index, resource_index, ok_id=None):
+    """Deletes a specified resource within a specific video of a lecture in a given course."""
+    user_courses = get_updated_user_courses()
+    int_course_ok_id = int(course_ok_id)
+    for course in user_courses:
+        if course['course_id'] == int_course_ok_id:
+            if course['role'] != consts.INSTRUCTOR:
+                return jsonify(success=False, message="Only instructors can delete resources"), 403
+            db[Resource.collection].delete_one(
+                {
+                    'course_ok_id': course_ok_id,
+                    'lecture_url_name': lecture_url_name,
+                    'video_index': video_index,
+                    'resource_index': resource_index
+                }
+            )
+            return jsonify(success=True), 200
+    return jsonify(success=False, message="Can only delete a resource on Hermes for an OK course you are a part of"), 403
+
 # @app.route('/course/<course_ok_id>/create_piazza_bot', methods=["POST"])
 # @validate_and_pass_on_ok_id
 # def create_piazza_bot(course_ok_id, ok_id=None):

--- a/app.py
+++ b/app.py
@@ -430,19 +430,55 @@ def create_vitamin(course_ok_id, lecture_url_name, video_index, ok_id=None):
     for course in user_courses:
         if course['course_id'] == int_course_ok_id:
             if course['role'] == consts.INSTRUCTOR:
-                if db[Course.collection].find_one({
-                    'course_ok_id': course_ok_id, 
-                    'lecture_url_name': lecture_url_name,
-                    'video_index': video_index
-                }):
+                if db[Video.collection].find_one({
+                        'course_ok_id': course_ok_id, 
+                        'lecture_url_name': lecture_url_name, 
+                        'video_index': video_index
+                    }):
                     try:
-                        form_data = request.form.to_dict()
-                        Vitamin.add_vitamin(form_data, db)
+                        vitamin = request.get_json().get('vitamin')
+                        Vitamin.add_vitamin(
+                            course_ok_id = int_course_ok_id,
+                            lecture_url_name = lecture_url_name,
+                            video_index = video_index,
+                            data = vitamin, 
+                            db = db
+                        )
                         return jsonify(success=True), 200
                     except ValueError as e:
                         return jsonify(success=False, message=str(e)), 500
             return jsonify(success=False, message="Only instructors can create vitamins"), 403
     return jsonify(success=False, message="Can only create a vitamin on Hermes for an OK course you are a part of"), 403
+
+@app.route('/course/<course_ok_id>/lecture/<lecture_url_name>/video/<int:video_index>/create_resource', methods=["POST"])
+@validate_and_pass_on_ok_id
+def create_resource(course_ok_id, lecture_url_name, video_index, ok_id=None):
+    """Creates a resource in the specified video within a lecture of a course."""
+
+    user_courses = get_updated_user_courses()
+    int_course_ok_id = int(course_ok_id)
+    for course in user_courses:
+        if course['course_id'] == int_course_ok_id:
+            if course['role'] == consts.INSTRUCTOR:
+                if db[Video.collection].find_one({
+                        'course_ok_id': course_ok_id, 
+                        'lecture_url_name': lecture_url_name, 
+                        'video_index': video_index
+                }):
+                    try:
+                        link = request.form.to_dict()['link']
+                        Resource.add_resource(
+                            course_ok_id = int_course_ok_id,
+                            lecture_url_name = lecture_url_name,
+                            video_index = video_index,
+                            link = link, 
+                            db = db
+                        )
+                        return jsonify(success=True), 200
+                    except ValueError as e:
+                        return jsonify(success=False, message=str(e)), 500
+            return jsonify(success=False, message="Only instructors can create resources"), 403
+    return jsonify(success=False, message="Can only create a resource on Hermes for an OK course you are a part of"), 403
 
 # @app.route('/course/<course_ok_id>/create_piazza_bot', methods=["POST"])
 # @validate_and_pass_on_ok_id

--- a/app.py
+++ b/app.py
@@ -21,7 +21,6 @@ import requests
 
 from utils.db_utils import User, Course, Lecture, Vitamin, Resource, Video, Transcript
 import utils.lecture_utils as LectureUtils
-# import utils.piazza_client as Piazza
 from utils.errors import CreateLectureFormValidationError
 
 from pprint import pprint
@@ -521,34 +520,3 @@ def delete_resource(course_ok_id, lecture_url_name, video_index, resource_index,
             )
             return jsonify(success=True), 200
     return jsonify(success=False, message="Can only delete a resource on Hermes for an OK course you are a part of"), 403
-
-# @app.route('/course/<course_ok_id>/create_piazza_bot', methods=["POST"])
-# @validate_and_pass_on_ok_id
-# def create_piazza_bot(course_ok_id, ok_id=None):
-#     user_courses = get_updated_user_courses()
-#     int_course_ok_id = int(course_ok_id)
-#     seperate_folders = request.form["piazza_folders"].split(" ")
-#     for course in user_courses:
-#         if course['course_id'] == int_course_ok_id:
-#             print(int_course_ok_id)
-#             if course['role'] == consts.INSTRUCTOR or user_courses[course_ok_id_key] == consts.STAFF:
-#                 if not request.form["piazza_course_id"].isalnum():
-#                     return jsonify(success=False, message="Please Enter a Valid Pizza API"), 403
-#                 if not seperate_folders:
-#                     return jsonify(success=False, message="Must include at one least folder for posts to go in"), 403
-#                 try:
-#                     Piazza.create_master_post(folders = seperate_folders, \
-#                     piazza_course_id  = request.form["piazza_course_id"], content = request.form["content"])
-#                     db['Courses'].update(
-#                         {'course_ok_id': course_ok_id},
-#                         {"$set" :
-#                             {"piazza_course_id" : request.form["piazza_course_id"],
-#                             "piazza_folders" : seperate_folders,
-#                             "piazza_active" : True}
-#                         }
-#                     )
-#                     return jsonify(success=True), 200
-#                 except ValueError as e:
-#                     return jsonify(success=False, message= consts.PIAZZA_ERROR_MESSAGE), 403
-#             return jsonify(success=False, message="Only staff can create a Piazza Bot"), 403
-#     return jsonify(success=False, message="Can only create a PiazzaBot on behalf of Hermes for an OK course you are a part of"), 403

--- a/test/run-tests
+++ b/test/run-tests
@@ -16,7 +16,7 @@ set -e
 echo "Running tests"
 flag=0
 passed=0
-total=6
+total=0
 if python3 ./test/test_app.py; then
 	echo "test_app Passed"
 	passed=$((passed + 1))
@@ -24,13 +24,7 @@ else
 	flag=1
 	echo "test_app_utils Failed"
 fi
-if python3 ./test/test_app_utils.py; then
-	echo "test_app_utils Passed"
-	passed=$((passed + 1))
-else
-	flag=1
-	echo "test_app_utils Failed"
-fi
+total=$((total + 1))
 if python3 ./test/test_db_utils.py; then
 	echo "test_db_utils Passed"
 	passed=$((passed + 1))
@@ -38,6 +32,7 @@ else
 	flag=1
 	echo "test_db_utils Failed"
 fi
+total=$((total + 1))
 if python3 ./test/test_textbook_utils.py; then
 	echo "test_textbook_utils Passed"
 	passed=$((passed + 1))
@@ -45,20 +40,23 @@ else
 	flag=1
 	echo "test_textbook_utils Failed"
 fi
-if python3 ./test/test_transcribe_utils.py; then
-	echo "test_transcribe_utils Passed"
+total=$((total + 1))
+if python3 ./test/test_lecture_utils.py; then
+	echo "test_lecture_utils Passed"
 	passed=$((passed + 1))
 else
 	flag=1
-	echo "test_transcribe_utils Failed"
+	echo "test_lecture_utils Failed"
 fi
-if python3 ./test/test_webpage_utils.py; then
-	echo "test_webpage_utils Passed"
+total=$((total + 1))
+if python3 ./test/test_youtube_client.py; then
+	echo "test_youtube_client Passed"
 	passed=$((passed + 1))
 else
 	flag=1
-	echo "test_webpage_utils Failed"
+	echo "test_youtube_client Failed"
 fi
+total=$((total + 1))
 if [ "$flag" == 1 ]; then
 		echo "Test Cases Failed"
 		echo "$passed/$total Test Cases Passed"

--- a/test/test_lecture_utils.py
+++ b/test/test_lecture_utils.py
@@ -23,7 +23,7 @@ EXPECTED_IDS = [
 
 INVALID_LINKS = ['asdf']
 
-ACCESS_TOKEN = None
+ACCESS_TOKEN = 'ya29.GltnBl_0TZT5AH_ZTFQt9XNRW3Qthq1KeMAbEqX4PrkAywM_bHleU1CObe7E0LcsBM_O5cOwG7e154aJk5ZqUDrE4Bbvqk5Fib-LaDLpxcMeSh6BxMmG1UKgLLVY'
 youtube_client = YoutubeClient(ACCESS_TOKEN)
 # TODO AY: Mock this for tests: see https://docs.python.org/3/library/unittest.mock.html
 

--- a/test/test_lecture_utils.py
+++ b/test/test_lecture_utils.py
@@ -5,20 +5,17 @@ sys.path.append("../utils")
 sys.path.append("./utils")
 import lecture_utils as LectureUtils
 from errors import InvalidLectureLinkError
+from urllib.error import URLError
 from youtube_client import YoutubeClient
 
 VALID_LINKS = [
-    'https://www.youtube.com/watch?v=M4hXAZiiIZw&list=PLbh6KXqwIdGAsHxGlkb6sEVv1kXtBHuc2',
     'https://www.youtube.com/watch?v=M4hXAZiiIZw',
-    'youtu.be/M4hXAZiiIZw',
-    'http://tinyurl.com/ya2u2yqk'
+    'youtu.be/M4hXAZiiIZw'
 ]
 
 EXPECTED_IDS = [
-    ['M4hXAZiiIZw', 'HIgDFXeGOIg'],
     ['M4hXAZiiIZw'],
-    ['M4hXAZiiIZw'],
-    ['M4hXAZiiIZw', 'HIgDFXeGOIg']
+    ['M4hXAZiiIZw']
 ]
 
 INVALID_LINKS = ['asdf']
@@ -30,12 +27,12 @@ youtube_client = YoutubeClient(ACCESS_TOKEN)
 def test_get_final_youtube_url():
     for valid_link in VALID_LINKS:
         url = LectureUtils.get_final_youtube_url(valid_link)
-        assert url is not None
+        assert 'https://www.youtube.com/watch?v=M4hXAZiiIZw' in url
     for invalid_link in INVALID_LINKS:
         try:
             url = LectureUtils.get_final_youtube_url(invalid_link)
             assert False
-        except InvalidLectureLinkError as e:
+        except Exception as e:
             assert e is not None
 
 def test_get_youtube_ids():
@@ -45,5 +42,5 @@ def test_get_youtube_ids():
         assert video_ids == expected_ids
 
 if __name__ == '__main__':
-    # test_get_final_youtube_url()
+    test_get_final_youtube_url()
     test_get_youtube_ids()

--- a/test/test_youtube_client.py
+++ b/test/test_youtube_client.py
@@ -5,6 +5,7 @@ sys.path.append("../utils")
 sys.path.append("./utils")
 import lecture_utils as LectureUtils
 from errors import InvalidLectureLinkError
+from urllib.error import URLError
 from youtube_client import YoutubeClient
 
 LINKS = [
@@ -16,8 +17,9 @@ EXPECTED_ID = 'M4hXAZiiIZw'
 EXPECTED_LIST = 'PLbh6KXqwIdGAsHxGlkb6sEVv1kXtBHuc2'
 EXPECTED_LIST_IDS = ['M4hXAZiiIZw', 'HIgDFXeGOIg']
 
-ACCESS_TOKEN = "ya29.GltnBl_0TZT5AH_ZTFQt9XNRW3Qthq1KeMAbEqX4PrkAywM_bHleU1CObe7E0LcsBM_O5cOwG7e154aJk5ZqUDrE4Bbvqk5Fib-LaDLpxcMeSh6BxMmG1UKgLLVY"
+ACCESS_TOKEN = 'ya29.GltnBl_0TZT5AH_ZTFQt9XNRW3Qthq1KeMAbEqX4PrkAywM_bHleU1CObe7E0LcsBM_O5cOwG7e154aJk5ZqUDrE4Bbvqk5Fib-LaDLpxcMeSh6BxMmG1UKgLLVY'
 youtube_client = YoutubeClient(ACCESS_TOKEN)
+# TODO AY: Mock this for tests: see https://docs.python.org/3/library/unittest.mock.html
 
 def test_get_youtube_id():
 	for link in LINKS:
@@ -49,4 +51,5 @@ if __name__ == '__main__':
 	test_get_youtube_id()
 	test_get_link_metadata()
 	test_create_video_link()
-	test_get_playlist_video_ids()
+	# test_get_playlist_video_ids()
+	# youtube_client.get_transcript(EXPECTED_ID)

--- a/test/test_youtube_client.py
+++ b/test/test_youtube_client.py
@@ -16,7 +16,7 @@ EXPECTED_ID = 'M4hXAZiiIZw'
 EXPECTED_LIST = 'PLbh6KXqwIdGAsHxGlkb6sEVv1kXtBHuc2'
 EXPECTED_LIST_IDS = ['M4hXAZiiIZw', 'HIgDFXeGOIg']
 
-ACCESS_TOKEN = "ya29.GluJBq5pEbUHh28g16bNDEXyCBoX0XwcmkaTvJSUffAMqVvaac4EOpRzksJ5VxY0IJGx0m_4zMC2bruVl1ztOK_e3QeXH5_nzzJwPlihdsejrjz1A6ev3m-WMG8j"
+ACCESS_TOKEN = "ya29.GltnBl_0TZT5AH_ZTFQt9XNRW3Qthq1KeMAbEqX4PrkAywM_bHleU1CObe7E0LcsBM_O5cOwG7e154aJk5ZqUDrE4Bbvqk5Fib-LaDLpxcMeSh6BxMmG1UKgLLVY"
 youtube_client = YoutubeClient(ACCESS_TOKEN)
 
 def test_get_youtube_id():

--- a/test/test_youtube_client.py
+++ b/test/test_youtube_client.py
@@ -1,0 +1,52 @@
+import os, sys
+sys.path.append(".")
+sys.path.append("..")
+sys.path.append("../utils")
+sys.path.append("./utils")
+import lecture_utils as LectureUtils
+from errors import InvalidLectureLinkError
+from youtube_client import YoutubeClient
+
+LINKS = [
+    'https://www.youtube.com/watch?v=M4hXAZiiIZw&list=PLbh6KXqwIdGAsHxGlkb6sEVv1kXtBHuc2',
+    'https://www.youtube.com/watch?v=M4hXAZiiIZw'
+]
+
+EXPECTED_ID = 'M4hXAZiiIZw'
+EXPECTED_LIST = 'PLbh6KXqwIdGAsHxGlkb6sEVv1kXtBHuc2'
+EXPECTED_LIST_IDS = ['M4hXAZiiIZw', 'HIgDFXeGOIg']
+
+ACCESS_TOKEN = "ya29.GluJBq5pEbUHh28g16bNDEXyCBoX0XwcmkaTvJSUffAMqVvaac4EOpRzksJ5VxY0IJGx0m_4zMC2bruVl1ztOK_e3QeXH5_nzzJwPlihdsejrjz1A6ev3m-WMG8j"
+youtube_client = YoutubeClient(ACCESS_TOKEN)
+
+def test_get_youtube_id():
+	for link in LINKS:
+		assert EXPECTED_ID == YoutubeClient.get_youtube_id(link)
+
+def test_get_link_metadata():
+	metadata = YoutubeClient.get_link_metadata(LINKS[0])
+	assert metadata['playlist_id'] == EXPECTED_LIST
+	assert metadata['video_id'] == EXPECTED_ID
+
+	metadata = YoutubeClient.get_link_metadata(LINKS[1])
+	assert 'playlist_id' not in metadata
+	assert metadata['video_id'] == EXPECTED_ID
+
+def test_create_video_link():
+	assert YoutubeClient.create_video_link(EXPECTED_ID, EXPECTED_LIST) == LINKS[0]
+	assert YoutubeClient.create_video_link(EXPECTED_ID) == LINKS[1]
+
+def test_get_playlist_video_ids():
+	video_ids = youtube_client.get_playlist_video_ids(EXPECTED_LIST)
+	assert len(video_ids) == len(EXPECTED_LIST_IDS)
+	for i in range(len(video_ids)):
+		assert EXPECTED_LIST_IDS[i] == video_ids[i]
+
+
+
+
+if __name__ == '__main__':
+	test_get_youtube_id()
+	test_get_link_metadata()
+	test_create_video_link()
+	test_get_playlist_video_ids()

--- a/test/test_youtube_client.py
+++ b/test/test_youtube_client.py
@@ -17,7 +17,7 @@ EXPECTED_ID = 'M4hXAZiiIZw'
 EXPECTED_LIST = 'PLbh6KXqwIdGAsHxGlkb6sEVv1kXtBHuc2'
 EXPECTED_LIST_IDS = ['M4hXAZiiIZw', 'HIgDFXeGOIg']
 
-ACCESS_TOKEN = 'ya29.GltnBl_0TZT5AH_ZTFQt9XNRW3Qthq1KeMAbEqX4PrkAywM_bHleU1CObe7E0LcsBM_O5cOwG7e154aJk5ZqUDrE4Bbvqk5Fib-LaDLpxcMeSh6BxMmG1UKgLLVY'
+ACCESS_TOKEN = 'ya29.GluNBlIdi9OWI43-GbCUEx6Gtl3gvdVXf2qGIXxnQSvjy9055EgjcXWH1oK-Cb77HSN9-2pAX0aT3ZUawYZ7sQIqAIDXS91ImN9nPpD0EhThV7UmaHZk-xGhgjGa'
 youtube_client = YoutubeClient(ACCESS_TOKEN)
 # TODO AY: Mock this for tests: see https://docs.python.org/3/library/unittest.mock.html
 
@@ -51,5 +51,5 @@ if __name__ == '__main__':
 	test_get_youtube_id()
 	test_get_link_metadata()
 	test_create_video_link()
-	# test_get_playlist_video_ids()
+	test_get_playlist_video_ids()
 	# youtube_client.get_transcript(EXPECTED_ID)

--- a/utils/db_utils.py
+++ b/utils/db_utils.py
@@ -242,13 +242,6 @@ class Vitamin(DBObject):
             }
         )
 
-    @staticmethod
-    def delete_vitamin(vitamin, db):
-        vitamin_id = vitamin['vitamin_id']
-        db[Vitamin.collection].delete_one(
-            {'_id': ObjectId(vitamin_id)}
-        )
-
 
 
 class Resource(DBObject):
@@ -289,13 +282,6 @@ class Resource(DBObject):
                     'num_resources': video['num_resources'] + 1
                 }
             }
-        )
-
-    @staticmethod
-    def delete_resource(resource, db):
-        resource_id = resource['resource_id']
-        db[Resource.collection].delete_one(
-            {'_id': ObjectId(resource_id)}
         )
 
 class Transcript(DBObject):

--- a/utils/db_utils.py
+++ b/utils/db_utils.py
@@ -206,20 +206,40 @@ class Vitamin(DBObject):
 
     @staticmethod
     def add_vitamin(course_ok_id, lecture_url_name, video_index, data, db):
-        print(data)
         timestamp = convert_seconds_to_timestamp(float(data['seconds']) // 1)
-        return insert(
+        video = db[Video.collection].find_one(
+            {
+                "course_ok_id": course_ok_id,
+                "lecture_url_name": lecture_url_name,
+                "video_index": video_index
+            }
+        )
+        vitamin_index = video['num_vitamins']
+        insert(
             Vitamin(
                 question = data['question'],
                 answer = data['answer'],
                 choices = data['choices'],
                 seconds = data['seconds'],
                 timestamp = timestamp,
+                vitamin_index = vitamin_index,
                 course_ok_id = course_ok_id,
                 lecture_url_name = lecture_url_name,
                 video_index = video_index
             ),
             db
+        )
+        db[Video.collection].update_one(
+            {
+                "course_ok_id": course_ok_id,
+                "lecture_url_name": lecture_url_name,
+                "video_index": video_index
+            },
+            {
+                '$set': {
+                    'num_vitamins': video['num_vitamins'] + 1
+                }
+            }
         )
 
     @staticmethod
@@ -240,14 +260,35 @@ class Resource(DBObject):
 
     @staticmethod
     def add_resource(course_ok_id, lecture_url_name, video_index, link, db):
-        return insert(
+        video = db[Video.collection].find_one(
+            {
+                "course_ok_id": course_ok_id,
+                "lecture_url_name": lecture_url_name,
+                "video_index": video_index
+            }
+        )
+        resource_index = video['num_resources']
+        insert(
             Resource(
                 link = link,
+                resource_index = resource_index,
                 course_ok_id = course_ok_id,
                 lecture_url_name = lecture_url_name,
                 video_index = video_index
             ),
             db
+        )
+        db[Video.collection].update_one(
+            {
+                "course_ok_id": course_ok_id,
+                "lecture_url_name": lecture_url_name,
+                "video_index": video_index
+            },
+            {
+                '$set': {
+                    'num_resources': video['num_resources'] + 1
+                }
+            }
         )
 
     @staticmethod

--- a/utils/db_utils.py
+++ b/utils/db_utils.py
@@ -205,18 +205,19 @@ class Vitamin(DBObject):
         DBObject.__init__(self, **attr)
 
     @staticmethod
-    def add_vitamin(data, db):
+    def add_vitamin(course_ok_id, lecture_url_name, video_index, data, db):
+        print(data)
         timestamp = convert_seconds_to_timestamp(float(data['seconds']) // 1)
-        choices = [data['choice' + str(i)] for i in range(1, 5) if len(data['choice' + str(i)]) > 0]
         return insert(
             Vitamin(
                 question = data['question'],
                 answer = data['answer'],
-                choices = choices,
+                choices = data['choices'],
                 seconds = data['seconds'],
                 timestamp = timestamp,
-                lecture_id = data['lecture_id'],
-                playlist_number = data['playlist_number']
+                course_ok_id = course_ok_id,
+                lecture_url_name = lecture_url_name,
+                video_index = video_index
             ),
             db
         )
@@ -238,12 +239,13 @@ class Resource(DBObject):
         DBObject.__init__(self, **attr)
 
     @staticmethod
-    def add_resource(data, db):
+    def add_resource(course_ok_id, lecture_url_name, video_index, link, db):
         return insert(
             Resource(
-                link = data['link'],
-                lecture_id = data['lecture_id'],
-                playlist_number = data['playlist_number']
+                link = link,
+                course_ok_id = course_ok_id,
+                lecture_url_name = lecture_url_name,
+                video_index = video_index
             ),
             db
         )

--- a/utils/lecture_utils.py
+++ b/utils/lecture_utils.py
@@ -54,7 +54,9 @@ def create_lecture(course_ok_id, db, lecture_title,
                 youtube_id=youtube_id,
                 course_ok_id=course_ok_id,
                 lecture_url_name=lecture_url_name,
-                video_index=video_index
+                video_index=video_index,
+                num_vitamins=0,
+                num_resources=0
             )
         )
         video_titles.append(title)

--- a/utils/youtube_client.py
+++ b/utils/youtube_client.py
@@ -72,7 +72,6 @@ class YoutubeClient:
 
     def get_playlist_video_ids(self, playlist_id):
         """Gets all YouTube video IDs associated with a playlist ID"""
-        print(playlist_id)
         response = self.youtube.playlistItems().list(
             part='contentDetails',
             maxResults=25,

--- a/utils/youtube_client.py
+++ b/utils/youtube_client.py
@@ -72,6 +72,7 @@ class YoutubeClient:
 
     def get_playlist_video_ids(self, playlist_id):
         """Gets all YouTube video IDs associated with a playlist ID"""
+        print(playlist_id)
         response = self.youtube.playlistItems().list(
             part='contentDetails',
             maxResults=25,


### PR DESCRIPTION
Added support for creating and deleting vitamins through URL paths. New Postman requests collection can be found in the drive.

For both vitamins and resources, an index is used to be able to refer to unique vitamins/resources when deleting them, using the same approach used for lectures (**Note**: Remember this count isn't actually accurate since deletions **do not** decrement the count to prevent index collisions for vitamins.). The "count" for vitamins and resources can be found in a Video object (old videos will not be able to have vitamins/resources since they do not have this variable). 